### PR TITLE
fix: improve celery performance

### DIFF
--- a/changelog.d/20241119_100430_crisgarta8_celery_queues.md
+++ b/changelog.d/20241119_100430_crisgarta8_celery_queues.md
@@ -1,0 +1,1 @@
+- 💥 [Feature] Add a filter to define the celery workers startup command. (by @Ian2012)

--- a/changelog.d/20241119_111602_fghaas_image_manifest.md
+++ b/changelog.d/20241119_111602_fghaas_image_manifest.md
@@ -1,0 +1,8 @@
+- [Improvement] When building images with
+  `tutor images build --cache-to-registry`, use an OCI-compliant cache
+  artifact format that should be universally compatible with all
+  registries. This enables the use of that option when working with
+  third-party registries such as [Harbor](https://goharbor.io/) or
+  [ECR](https://aws.amazon.com/ecr/). Requires
+  [BuildKit 0.12](https://github.com/moby/buildkit/releases/tag/v0.12.0)
+  or later. (by @angonz and @fghaas)

--- a/tutor/commands/images.py
+++ b/tutor/commands/images.py
@@ -227,7 +227,7 @@ def build(
                 image_build_args.append(f"--cache-from=type=registry,ref={tag}-cache")
             if cache_to_registry:
                 image_build_args.append(
-                    f"--cache-to=type=registry,mode=max,ref={tag}-cache"
+                    f"--cache-to=type=registry,mode=max,ref={tag}-cache,image-manifest=true"
                 )
 
             # Build contexts

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -514,6 +514,16 @@ class Filters:
     #: :param str file_path: The path to the file being checked.
     IS_FILE_RENDERED: Filter[bool, [str]] = Filter()
 
+    #: List of parameters to use when starting the LMS Celery worker ``celery worker ...``.
+    #:
+    #: :param list[str] command: the list of paramaters to use as the celery command.
+    LMS_WORKER_COMMAND: Filter[list[str], []] = Filter()
+
+    #: List of parameters to use when starting the CMS Celery worker ``celery worker ...``.
+    #:
+    #: :param list[str] command: the list of paramaters to use as the celery command.
+    CMS_WORKER_COMMAND: Filter[list[str], []] = Filter()
+
 
 class Contexts:
     """

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -142,3 +142,45 @@ def is_directory_mounted(image_name: str, dirname: str) -> bool:
 hooks.Filters.ENV_TEMPLATE_VARIABLES.add_item(
     ("iter_mounted_directories", iter_mounted_directories)
 )
+
+
+hooks.Filters.LMS_WORKER_COMMAND.add_items(
+    [
+        "celery",
+        "--app=lms.celery",
+        "worker",
+        "--loglevel=info",
+        "--hostname=edx.lms.core.default.%h",
+        "--queues=edx.lms.core.default,edx.lms.core.high,edx.lms.core.high_mem",
+        "--max-tasks-per-child=100",
+    ]
+)
+
+
+hooks.Filters.CMS_WORKER_COMMAND.add_items(
+    [
+        "celery",
+        "--app=cms.celery",
+        "worker",
+        "--loglevel=info",
+        "--hostname=edx.cms.core.default.%h",
+        "--queues=edx.cms.core.default,edx.cms.core.high,edx.cms.core.low",
+        "--max-tasks-per-child=100",
+    ]
+)
+
+
+def iter_cms_celery_parameters() -> t.Iterator[str]:
+    yield from hooks.Filters.CMS_WORKER_COMMAND.iterate()
+
+
+def iter_lms_celery_parameters() -> t.Iterator[str]:
+    yield from hooks.Filters.LMS_WORKER_COMMAND.iterate()
+
+
+hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
+    [
+        ("iter_cms_celery_parameters", iter_cms_celery_parameters),
+        ("iter_lms_celery_parameters", iter_lms_celery_parameters),
+    ]
+)

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -153,6 +153,9 @@ hooks.Filters.LMS_WORKER_COMMAND.add_items(
         "--hostname=edx.lms.core.default.%h",
         "--queues=edx.lms.core.default,edx.lms.core.high,edx.lms.core.high_mem",
         "--max-tasks-per-child=100",
+        "--without-gossip", # Disable worker communication. All messages should be captured from the broker.
+        "--without-mingle", # Disable worker synchronization.
+        "--heartbeat-interval=60", # Reduce the heartbeat interval to 1 min.
     ]
 )
 
@@ -166,6 +169,9 @@ hooks.Filters.CMS_WORKER_COMMAND.add_items(
         "--hostname=edx.cms.core.default.%h",
         "--queues=edx.cms.core.default,edx.cms.core.high,edx.cms.core.low",
         "--max-tasks-per-child=100",
+        "--without-gossip", # Disable worker communication. All messages should be captured from the broker.
+        "--without-mingle", # Disable worker synchronization.
+        "--heartbeat-interval=60", # Reduce the heartbeat interval to 1 min.
     ]
 )
 

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -141,7 +141,9 @@ spec:
       containers:
         - name: cms-worker
           image: {{ DOCKER_IMAGE_OPENEDX }}
-          args: ["celery", "--app=cms.celery", "worker", "--loglevel=info", "--hostname=edx.cms.core.default.%%h", "--max-tasks-per-child", "100", "--exclude-queues=edx.lms.core.default"]
+          args:
+          {% for value in iter_cms_celery_parameters() %}
+          - "{{value}}"{% endfor %}
           env:
           - name: SERVICE_VARIANT
             value: cms
@@ -250,7 +252,8 @@ spec:
       containers:
         - name: lms-worker
           image: {{ DOCKER_IMAGE_OPENEDX }}
-          args: ["celery", "--app=lms.celery", "worker", "--loglevel=info", "--hostname=edx.lms.core.default.%%h", "--max-tasks-per-child=100", "--exclude-queues=edx.cms.core.default"]
+          args: {% for value in iter_lms_celery_parameters() %}
+          - "{{value}}"{% endfor %}
           env:
           - name: SERVICE_VARIANT
             value: lms

--- a/tutor/templates/local/docker-compose.prod.yml
+++ b/tutor/templates/local/docker-compose.prod.yml
@@ -31,7 +31,8 @@ services:
     environment:
       SERVICE_VARIANT: lms
       DJANGO_SETTINGS_MODULE: lms.envs.tutor.production
-    command: celery --app=lms.celery worker --loglevel=info --hostname=edx.lms.core.default.%%h --max-tasks-per-child=100 --exclude-queues=edx.cms.core.default
+    command: {% for value in iter_lms_celery_parameters() %}
+      - "{{value}}"{% endfor %}
     restart: unless-stopped
     volumes:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
@@ -50,7 +51,8 @@ services:
     environment:
       SERVICE_VARIANT: cms
       DJANGO_SETTINGS_MODULE: cms.envs.tutor.production
-    command: celery --app=cms.celery worker --loglevel=info --hostname=edx.cms.core.default.%%h --max-tasks-per-child 100 --exclude-queues=edx.lms.core.default
+    command: {% for value in iter_lms_celery_parameters() %}
+      - "{{value}}"{% endfor %}
     restart: unless-stopped
     volumes:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro


### PR DESCRIPTION
### Description

This removes the `gossip` and `mingle` features to improve Celery's performance and reduce the number of messages sent to Redis. It also increases the heartbeat interval to `60s` from `2s`.


### References:

https://www.cloudamqp.com/blog/python-celery-and-rabbitmq.html
https://ankurdhuriya.medium.com/understanding-celery-workers-concurrency-prefetching-and-heartbeats-85707f28c506